### PR TITLE
fix @param to @return

### DIFF
--- a/Reflection/Reflection.php
+++ b/Reflection/Reflection.php
@@ -2099,7 +2099,7 @@ class ReflectionClassConstant implements Reflector {
      * Checks if class constant is public
      * @since 7.1
      * @link https://php.net/manual/en/reflectionclassconstant.ispublic.php
-     * @param bool
+     * @return bool
      */
 	public function isPublic() {}
 


### PR DESCRIPTION
correction of PHPdoc. There is no param to this function, only a return